### PR TITLE
Heartbeat

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -101,6 +101,75 @@ If you want retry to work for subscribing apps, you should run resque-scheduler
     
     $ rake resquebus:driver resque:scheduler
 
+### Heartbeat
+
+We've found it useful to have the bus act like cron. Triggering timed jobs throughout the system. Resque Bus calls this a heartbeat.
+It uses resque-scheduler to trigger the events. You can enable it in your Rakefile.
+
+    # resque.rake
+    namespace :resque do
+      task :setup => [:environment] do
+        ResqueBus.heartbeat!
+      end
+    end
+
+Or add it to your `schedule.yml` directly
+
+    resquebus_heartbeat:
+      cron: "* * * * *"
+      class: "::ResqueBus::Heartbeat"
+      queue: resquebus_incoming
+      description: "I publish a heartbeat_minutes event every minute"
+
+It is the equivalent of doing this every minute
+
+seconds = minutes * (60)
+hours   = minutes / (60)
+days    = minutes / (60*24)
+
+now     = Time.at(seconds)
+
+attributes = {}
+
+
+    now = Time.now
+    seconds = now.to_i
+    ResqueBus.publish("hearbeat_minutes", {
+      "epoch_seconds" => seconds,
+      "epoch_minutes" => seconds / 1.minute,
+      "epoch_hours"   => seconds / 1.hour,
+      "epoch_days"    => seconds / 1.day,
+      "minute"        => now.min
+      "hour"          => now.hour
+      "day"           => now.day
+      "month"         => now.month
+      "year"          => now.year
+      "yday"          => now.yday
+      "wday"          => now.wday
+    })
+
+This allows you do something like this:
+
+    ResqueBus.dispatch("app_c") do
+      # runs at 10:20, 11:20, etc
+      subscribe "once_an_hour", 'bus_event_type' => 'heartbeat_minutes', 'minute' => 20 do |attributes|
+        Sitemap.generate!
+      end
+      
+      # runs every five minutes
+      subscribe "every_five_minutes", 'bus_event_type' => 'heartbeat_minutes' do |attributes|
+        next unless attributes["epoch_minutes"] % 5 == 0
+        HealthCheck.run!
+      end
+      
+      # runs at 8am on the first of every month
+      subscribe "new_month_morning", 'bus_event_type' => 'heartbeat_minutes', 'day' => 1, hour' => 8, 'minute' => 0,  do |attributes|
+        next unless attributes["epoch_minutes"] % 5 == 0
+        Token.old.expire!
+      end
+    end
+
+
 ### Compatibility
 
 ResqueBus can live along side another instance of Resque that points at a different Redis server.

--- a/lib/resque_bus/driver.rb
+++ b/lib/resque_bus/driver.rb
@@ -13,7 +13,7 @@ module ResqueBus
       end
 
       def perform(attributes={})
-        raise "No attribiutes passed" if attributes.empty?
+        raise "No attributes passed" if attributes.empty?
 
         ResqueBus.log_worker("Driver running: #{attributes.inspect}")
 

--- a/lib/resque_bus/heartbeat.rb
+++ b/lib/resque_bus/heartbeat.rb
@@ -1,0 +1,96 @@
+module ResqueBus
+  # publishes event about the current time
+  class Heartbeat
+
+    class << self
+      
+      def lock_key
+        "resquebus:heartbeat:lock"
+      end
+      
+      def lock_seconds
+        60
+      end
+      
+      def lock!
+        now = Time.now.to_i
+        timeout = now + lock_seconds + 2
+
+        # return true if we successfully acquired the lock
+        return timeout if Resque.redis.setnx(lock_key, timeout)
+
+        # see if the existing timeout is still valid and return false if it is
+        # (we cannot acquire the lock during the timeout period)
+        return 0 if now <= Resque.redis.get(lock_key).to_i
+
+        # otherwise set the timeout and ensure that no other worker has
+        # acquired the lock
+        if now > Resque.redis.getset(lock_key, timeout).to_i
+          return timeout
+        else
+          return 0
+        end
+      end
+      
+      def unlock!
+        Resque.redis.del(lock_key)
+      end
+      
+      
+      def redis_key
+        "resquebus:heartbeat:timestamp"
+      end
+
+      def get_saved_minute!
+        key = ResqueBus.redis.get(redis_key)
+        return nil if key.nil?
+        return key.to_i
+      end
+
+      def set_saved_minute!(epoch_minute)
+        ResqueBus.redis.set(redis_key, epoch_minute)
+      end
+      
+      def perform
+        real_now = Time.now.to_i
+        run_until = lock! - 2
+        return if run_until < real_now
+        
+        while((real_now = Time.now.to_i) < run_until)
+          minutes = real_now.to_i / 60
+          last = get_saved_minute!
+          if last
+            break if minutes <= last
+            minutes = last + 1
+          end
+
+          seconds = minutes * (60)
+          hours   = minutes / (60)
+          days    = minutes / (60*24)
+
+          now     = Time.at(seconds)
+
+          attributes = {}
+          attributes["epoch_seconds"] = seconds
+          attributes["epoch_minutes"] = minutes
+          attributes["epoch_hours"]   = hours
+          attributes["epoch_days"]    = days
+
+          attributes["minute"] = now.min
+          attributes["hour"]   = now.hour
+          attributes["day"]    = now.day
+          attributes["month"]  = now.month
+          attributes["year"]   = now.year
+          attributes["yday"]   = now.yday
+          attributes["wday"]   = now.wday
+
+          ResqueBus.publish("heartbeat_minutes", attributes)
+          set_saved_minute!(minutes)
+        end
+
+        unlock!
+      end
+    end
+
+  end
+end

--- a/lib/resque_bus/version.rb
+++ b/lib/resque_bus/version.rb
@@ -1,5 +1,5 @@
 module Resque
   module Bus
-    VERSION = "0.2.10"
+    VERSION = "0.3.0"
   end
 end

--- a/spec/driver_spec.rb
+++ b/spec/driver_spec.rb
@@ -34,7 +34,7 @@ module ResqueBus
       end
     end
     
-    describe ".peform" do
+    describe ".perform" do
       let(:attributes) { {"x" => "y"} }
       
       before(:each) do

--- a/spec/heartbeat_spec.rb
+++ b/spec/heartbeat_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+module ResqueBus
+  describe Heartbeat do
+    def now_attributes
+      {
+        "epoch_seconds" => (Time.now.to_i / 60) * 60, # rounded
+        "epoch_minutes" => Time.now.to_i / 60,
+        "epoch_hours"   => Time.now.to_i / (60*60),
+        "epoch_days"    => Time.now.to_i / (60*60*24),
+        "minute" => Time.now.min,
+        "hour"   => Time.now.hour,
+        "day"    => Time.now.day,
+        "month"  => Time.now.month,
+        "year"   => Time.now.year,
+        "yday"   => Time.now.yday,
+        "wday"   => Time.now.wday
+      }
+    end
+    
+    it "should publish the current time once" do
+      Timecop.freeze "12/12/2013 12:01:19" do
+        ResqueBus.should_receive(:publish).with("heartbeat_minutes", now_attributes)
+        Heartbeat.perform
+      end
+      
+      Timecop.freeze "12/12/2013 12:01:40" do
+        Heartbeat.perform
+      end
+    end
+    
+    it "should publish a minute later" do
+      Timecop.freeze "12/12/2013 12:01:19" do
+        ResqueBus.should_receive(:publish).with("heartbeat_minutes", now_attributes)
+        Heartbeat.perform
+      end
+      
+      debugger
+      
+      Timecop.freeze "12/12/2013 12:02:01" do
+        ResqueBus.should_receive(:publish).with("heartbeat_minutes", now_attributes)
+        Heartbeat.perform
+      end
+    end
+  end
+end


### PR DESCRIPTION
We've found it useful to have the bus act like cron. Triggering timed jobs throughout the system. Resque Bus calls this a heartbeat.
It uses resque-scheduler to trigger the events. You can enable it in your Rakefile.

```
# resque.rake
namespace :resque do
  task :setup => [:environment] do
    ResqueBus.heartbeat!
  end
end
```

Or add it to your `schedule.yml` directly

```
resquebus_heartbeat:
  cron: "* * * * *"
  class: "::ResqueBus::Heartbeat"
  queue: resquebus_incoming
  description: "I publish a heartbeat_minutes event every minute"
```

It is the equivalent of doing this every minute

seconds = minutes \* (60)
hours   = minutes / (60)
days    = minutes / (60*24)

now     = Time.at(seconds)

attributes = {}

```
now = Time.now
seconds = now.to_i
ResqueBus.publish("hearbeat_minutes", {
  "epoch_seconds" => seconds,
  "epoch_minutes" => seconds / 1.minute,
  "epoch_hours"   => seconds / 1.hour,
  "epoch_days"    => seconds / 1.day,
  "minute"        => now.min
  "hour"          => now.hour
  "day"           => now.day
  "month"         => now.month
  "year"          => now.year
  "yday"          => now.yday
  "wday"          => now.wday
})
```

This allows you do something like this:

```
ResqueBus.dispatch("app_c") do
  # runs at 10:20, 11:20, etc
  subscribe "once_an_hour", 'bus_event_type' => 'heartbeat_minutes', 'minute' => 20 do |attributes|
    Sitemap.generate!
  end

  # runs every five minutes
  subscribe "every_five_minutes", 'bus_event_type' => 'heartbeat_minutes' do |attributes|
    next unless attributes["epoch_minutes"] % 5 == 0
    HealthCheck.run!
  end

  # runs at 8am on the first of every month
  subscribe "new_month_morning", 'bus_event_type' => 'heartbeat_minutes', 'day' => 1, hour' => 8, 'minute' => 0,  do |attributes|
    next unless attributes["epoch_minutes"] % 5 == 0
    Token.old.expire!
  end
end
```
